### PR TITLE
Use uintptr instead of runtime.Frame

### DIFF
--- a/error.go
+++ b/error.go
@@ -5,13 +5,6 @@ import (
 	"runtime"
 )
 
-const defaultStackCap = 20
-
-type withStack struct {
-	origin error
-	stack  []runtime.Frame
-}
-
 func (e *withStack) Error() string {
 	return e.origin.Error()
 }
@@ -21,48 +14,88 @@ func (e *withStack) Unwrap() error {
 }
 
 func (e *withStack) StackTrace() []runtime.Frame {
-	return e.stack
+	return e.stack.StackTrace()
 }
 
-func trace(err error, offset int) *withStack {
-	e := withStack{
-		origin: err,
-		stack:  make([]runtime.Frame, 0, defaultStackCap),
-	}
-
-	for {
-		if f, ok := getFrame(offset); ok {
-			e.stack = append(e.stack, f)
-			offset++
-			continue
-		}
-
-		break
-	}
-
-	return &e
+type withStack struct {
+	origin error
+	*stack
 }
 
-func getFrame(caller int) (runtime.Frame, bool) {
-	pc, file, line, ok := runtime.Caller(caller)
-	if !ok {
-		return runtime.Frame{}, false
-	}
+// frame represents a program counter inside a stack frame.
+// For historical reasons if Frame is interpreted as a uintptr
+// its value represents the program counter + 1.
+type frame uintptr
 
-	f := runtime.Frame{
-		PC:   pc,
-		File: file,
-		Line: line,
-	}
+// pc returns the program counter for this frame;
+// multiple frames may have the same PC value.
+func (f frame) pc() uintptr { return uintptr(f) - 1 }
 
-	fn := runtime.FuncForPC(pc)
+// file returns the full path to the file that contains the
+// function for this Frame's pc.
+func (f frame) file() string {
+	fn := runtime.FuncForPC(f.pc())
 	if fn == nil {
-		return f, true
+		return "unknown"
+	}
+	file, _ := fn.FileLine(f.pc())
+	return file
+}
+
+// line returns the line number of source code of the
+// function for this Frame's pc.
+func (f frame) line() int {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return 0
+	}
+	_, line := fn.FileLine(f.pc())
+	return line
+}
+
+// name returns the name of this function, if known.
+func (f frame) name() string {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return "unknown"
+	}
+	return fn.Name()
+}
+
+func (f frame) runtime() runtime.Frame {
+	rf := runtime.Frame{
+		PC:   f.pc(),
+		File: f.file(),
+		Line: f.line(),
 	}
 
-	f.Func = fn
-	f.Function = fn.Name()
-	f.Entry = fn.Entry()
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return rf
+	}
 
-	return f, true
+	rf.Func = fn
+	rf.Function = fn.Name()
+	rf.Entry = fn.Entry()
+
+	return rf
+}
+
+// stack represents a stack of program counters.
+type stack []uintptr
+
+func (s *stack) StackTrace() []runtime.Frame {
+	f := make([]runtime.Frame, len(*s))
+	for i := 0; i < len(f); i++ {
+		f[i] = frame((*s)[i]).runtime()
+	}
+	return f
+}
+
+func callers() *stack {
+	const depth = 32
+	var pcs [depth]uintptr
+	n := runtime.Callers(3, pcs[:])
+	var st stack = pcs[0:n]
+	return &st
 }

--- a/stack.go
+++ b/stack.go
@@ -7,12 +7,13 @@ import (
 	"strconv"
 )
 
-const offset = 3
-
 // Errorf saves stack trace and pass arguments to
 // fmt.Errorf.
 func Errorf(format string, a ...interface{}) error {
-	return trace(fmt.Errorf(format, a...), offset)
+	return &withStack{
+		fmt.Errorf(format, a...),
+		callers(),
+	}
 }
 
 // Origin returns unwrapped origin of the error.
@@ -32,7 +33,7 @@ func Origin(err error) error {
 
 // Trace returns stack trace for error.
 func Trace(err error) []runtime.Frame {
-	stack := make([]runtime.Frame, 0, defaultStackCap)
+	stack := make([]runtime.Frame, 0, 30)
 
 	for {
 		if err == nil {


### PR DESCRIPTION
Before:
```
BenchmarkErrorf/5-frames-4         	  158538	      7573 ns/op	    2992 B/op	      16 allocs/op
BenchmarkErrorf/10-frames-4        	   89179	     13124 ns/op	    4072 B/op	      26 allocs/op
BenchmarkErrorf/20-frames-4        	   44906	     26946 ns/op	    6232 B/op	      46 allocs/op
BenchmarkErrorf/40-frames-4        	   18634	     78400 ns/op	   13754 B/op	      87 allocs/op
```

After:

```
BenchmarkErrorf/5-frames-4         	  937490	      1248 ns/op	     384 B/op	       6 allocs/op
BenchmarkErrorf/10-frames-4        	  844726	      1510 ns/op	     384 B/op	       6 allocs/op
BenchmarkErrorf/20-frames-4        	  659119	      1842 ns/op	     384 B/op	       6 allocs/op
BenchmarkErrorf/40-frames-4        	  599695	      2035 ns/op	     384 B/op	       6 allocs/op
```